### PR TITLE
added bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,27 @@
+{
+  "name": "Google-Maps-TSP-Solver",
+  "version": "1.1.0",
+  "homepage": "https://github.com/TechNaturally/Google-Maps-TSP-Solver",
+  "authors": [
+    "James Tolley <info [at] gmaptools.com>",
+    "Geir K. Engdahl <geir.engdahl (at) gmail.com>"
+  ],
+  "description": "",
+  "main": ["tsp.js", "BpTspSolver.js"],
+  "moduleType": [],
+  "keywords": [
+    "google",
+    "maps",
+    "travelling",
+    "salesman",
+    "problem"
+  ],
+  "license": "MIT",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ]
+}


### PR DESCRIPTION
I see there's a bower package google-maps-tsp-solver registered to your repository, but without a bower.json file, certain utilities don't like it.

I've registered [my fork](https://github.com/TechNaturally/Google-Maps-TSP-Solver) as the bower package Google-Maps-TSP-Solver ... but I will remove it if you merge in the bower.json
